### PR TITLE
Fix case sensitivity in sales log source filter

### DIFF
--- a/src/app/sales-log/page.js
+++ b/src/app/sales-log/page.js
@@ -68,7 +68,7 @@ export default function SalesLogPage() {
 
   const filtered = useMemo(() => {
     return (data.rows || []).filter(r => {
-      const okSource = source === 'All' ? true : (r.source || '') === source;
+      const okSource = source === 'All' ? true : (r.source || '').toLowerCase() === source;
       const okRep = salesperson === 'All' ? true : (r.salesperson || '—') === salesperson;
       return okSource && okRep;
     });


### PR DESCRIPTION
## Summary
- ensure the sales log source filter compares lowercase values so options match rows regardless of casing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5f9917f7c833384041dc74156d008